### PR TITLE
copy templates directory on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/artofrawr/webpack-iconfont-plugin"
   },
   "scripts": {
-    "build": "babel --ignore __tests__ -s inline -d dist src",
+    "build": "babel --ignore __tests__ --copy-files -s inline -d dist src",
     "prepublish": "npm test && npm run build",
     "test": "jest"
   },


### PR DESCRIPTION
Fixes #5 

As mentioned in #5, [`--copy-files`](https://babeljs.io/docs/usage/cli/) copies over everything from the source directory to the target directory which was not either compiled or explicitly excluded (notably, the tests).

I've confirmed that after running `npm run build`, `dist` includes the `templates` directory with the two scss templates.

Cheers!