### PR TITLE
clone options to prevent nunjucks from clobbering them

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/artofrawr/webpack-iconfont-plugin"
   },
   "scripts": {
-    "build": "babel --ignore __tests__ -s inline -d dist src",
+    "build": "babel --ignore __tests__ --copy-files -s inline -d dist src",
     "prepublish": "npm test && npm run build",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "async-throttle": "^1.1.0",
+    "clone-deep": "^1.0.0",
     "fs-extra": "^3.0.0",
     "glob-parent": "^3.1.0",
     "globby": "^6.1.0",

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,3 +1,4 @@
+import cloneDeep from 'clone-deep';
 import createThrottle from 'async-throttle';
 import defaultMetadataProvider from 'svgicons2svgfont/src/metadata';
 import fileSorter from 'svgicons2svgfont/src/filesorter';
@@ -251,18 +252,16 @@ export default function(initialOptions) {
               return glyphData.metadata;
             })
           },
-          options,
+          cloneDeep(options),
           {
             fontName: options.fontName,
             fontPath: options.cssFontPath
           }
         );
-
         result.styles = nunjucks.render(
           templateFilePath,
           nunjucksOptions
         );
-
         return result;
       }).then(result => {
         if (options.formats.indexOf('svg') === -1) {


### PR DESCRIPTION
fixes #7 

as mentioned in #7, `nunjucks.render` apparently clobbers the `formats` array. 

This clones `options` provided to the nunjucks config object so that the plugin's logic is shielded from the mutation. 

With the following logging:

```js
console.log('before', options.formats);
result.styles = nunjucks.render(
  templateFilePath,
  nunjucksOptions
);
console.log('after', options.formats);
```

before this change:

```bash
before [ 'svg', 'ttf', 'eot', 'woff', 'woff2' ]
after [ 'svg', 'woff' ]
```

after this change:

```bash
before [ 'svg', 'ttf', 'eot', 'woff', 'woff2' ]
after [ 'svg', 'ttf', 'eot', 'woff', 'woff2' ]
```

: D